### PR TITLE
Inherit dependencies when running tests in a Boot pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Inherit dependencies in Boot pod without modification
+
 ## Changed
 
 # 0.0-14 (2019-01-14 / 4c7053e)

--- a/src/kaocha/boot_task.clj
+++ b/src/kaocha/boot_task.clj
@@ -8,8 +8,6 @@
 
 (defn make-kaocha-pod []
   (-> (boot/get-env)
-      (update-in [:dependencies] conj
-                 '[lambdaisland/kaocha "0.0-337"])
       pod/make-pod))
 
 (boot/deftask kaocha


### PR DESCRIPTION
This should fix https://github.com/lambdaisland/kaocha-boot/issues/2 by no longer forcing a specific version of `lambdaisland/kaocha` in the pod.

Thanks!